### PR TITLE
feat: single-page playground with sidebar redesign

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -44,6 +44,17 @@ module.exports = function (eleventyConfig) {
     return array.filter((item) => item.data ? item.data[key] === value : item[key] === value);
   });
 
+  // Slug filter — convert title to URL-safe anchor id
+  eleventyConfig.addFilter("slug", function (value) {
+    if (!value) return "";
+    return value.toString().toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^\w-]+/g, "")
+      .replace(/--+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "");
+  });
+
   // Sort filter (works on arrays of objects)
   eleventyConfig.addFilter("sort_by", function (array, key) {
     if (!array) return [];

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,5 +1,19 @@
-- title: Overview
-  url: /
+- title: Getting Started
+  url: "#top"
+  icon: ti-rocket
 
-- title: Components
-  group: components
+- title: Layout
+  section: layout
+  icon: ti-layout
+
+- title: Actions
+  section: actions
+  icon: ti-click
+
+- title: Feedback
+  section: feedback
+  icon: ti-bell
+
+- title: Data
+  section: data
+  icon: ti-chart-bar

--- a/docs/_includes/default.html
+++ b/docs/_includes/default.html
@@ -25,11 +25,10 @@
       })();
     </script>
   </head>
-  <body>
+  <body data-bs-spy="scroll" data-bs-target="#sidebar-nav" data-bs-offset="100" tabindex="0">
     {% include "navigation.html" %}
-    <div class="main-content">
+    <div class="main-content" id="main-content">
       <div class="container">
-        {% include "page-header.html" %}
         {{ content}}
       </div>
     </div>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,4 +1,5 @@
-    <nav class="main-nav navbar navbar-expand-md navbar-light" id="sidebar" role="navigation">
+    <a href="#main-content" class="visually-hidden-focusable">Skip to content</a>
+    <nav class="main-nav navbar navbar-expand-md navbar-light" id="sidebar" role="navigation" aria-label="Component navigation">
         <div class="main-nav__content">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarCollapse" aria-controls="sidebarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -8,33 +9,30 @@
                 <img src="/assets/img/next-commerce-logo-white.svg" class="logo-dark">
             </a>
             <div class="collapse navbar-collapse show" id="sidebarCollapse">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav" id="sidebar-nav">
                     {% for item in navigation %}
-                        {% if item.group %}
+                        {% if item.section %}
+                            <!-- Group heading -->
+                            <li class="nav-item nav-group-heading">
+                                <span class="nav-group-label">
+                                    <i class="ti {{ item.icon }}"></i>
+                                    {{ item.title }}
+                                </span>
+                            </li>
+                            <!-- Component links in this section -->
+                            {% assign section_comps = collections.components | where: "section", item.section %}
+                            {% for comp in section_comps %}
+                                <li class="nav-item nav-sub-item">
+                                    <a class="nav-link" href="#{{ comp.data.title | slug }}">{{ comp.data.title }}</a>
+                                </li>
+                            {% endfor %}
+                        {% else %}
+                            <!-- Direct link (Getting Started) -->
                             <li class="nav-item">
-                                <a class="nav-link {% if page.url contains item.group %}active{% endif %}"
-                                   role="button" data-bs-toggle="collapse" data-bs-target="#{{ item.group }}"
-                                   aria-expanded="{% if page.url contains item.group %}true{% else %}false{% endif %}"
-                                   aria-controls="{{ item.group }}">
+                                <a class="nav-link" href="{{ item.url }}">
+                                    <i class="ti {{ item.icon }}"></i>
                                     {{ item.title }}
                                 </a>
-                                <div class="{% if page.url contains item.group %}collapse show{% else %}collapse{% endif %}" id="{{ item.group }}">
-                                    <ul class="nav flex-column">
-                                        {% for comp in collections.components %}
-                                            <li>
-                                                <a class="nav-link {% if comp.url == page.url %}active{% endif %}"
-                                                   href="{{ comp.url }}"
-                                                   {% if comp.url == page.url %}aria-current="true"{% endif %}>
-                                                    {{ comp.data.title }}
-                                                </a>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                            </li>
-                        {% else %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if page.url == item.url %}active{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
                             </li>
                         {% endif %}
                     {% endfor %}

--- a/docs/_includes/playground.html
+++ b/docs/_includes/playground.html
@@ -1,0 +1,53 @@
+---
+layout: default
+---
+<div id="top" class="row justify-content-center">
+  <div class="col-12 py-5">
+
+    <!-- Getting Started section -->
+    <div class="pt-3 pb-4 border-bottom mb-5">
+      <h1 class="display-5">{{ title }}</h1>
+      {% if description %}
+        <p class="mb-0">{{ description }}</p>
+      {% endif %}
+    </div>
+
+    {{ content }}
+
+    <!-- Component sections grouped by category -->
+    {% assign sections = "layout,actions,feedback,data" | split: "," %}
+    {% assign section_titles = "Layout,Actions,Feedback,Data" | split: "," %}
+    {% assign section_icons = "ti-layout,ti-click,ti-bell,ti-chart-bar" | split: "," %}
+
+    {% for section in sections %}
+      {% assign section_index = forloop.index0 %}
+      {% assign section_components = collections.components | where: "section", section %}
+
+      {% if section_components.size > 0 %}
+        <!-- Section group heading -->
+        <div class="section-group-heading" id="section-{{ section }}">
+          <i class="ti {{ section_icons[section_index] }}"></i>
+          <h6>{{ section_titles[section_index] }}</h6>
+        </div>
+
+        {% for comp in section_components %}
+          <section id="{{ comp.data.title | slug }}" class="component-section">
+            <h2 class="display-6 mb-2">{{ comp.data.title }}</h2>
+            {% if comp.data.description %}
+              <p class="text-muted mb-4">{{ comp.data.description }}</p>
+            {% endif %}
+            {{ comp.content }}
+          </section>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+
+    <!-- Footer -->
+    <footer class="text-center py-5 mt-5 border-top">
+      <p class="text-muted mb-2">Built with the NEXT Commerce Design System</p>
+      <a href="https://github.com/NextCommerceCo/app-ui-framework" class="text-muted me-3" target="_blank">View on GitHub</a>
+      <a href="#top" class="text-muted">Back to top</a>
+    </footer>
+
+  </div>
+</div>

--- a/docs/_sass/_layout.scss
+++ b/docs/_sass/_layout.scss
@@ -75,19 +75,58 @@
 
     .navbar-nav {
         .nav-link {
-            padding: 0.625rem 1.5rem;
+            padding: 0.375rem 1.5rem;
             min-height: 44px;
             align-items: center;
             display: flex;
+            color: $gray-700;
+            font-size: $font-size-sm;
+            transition: color 0.15s ease, border-color 0.15s ease;
+            border-left: 3px solid transparent;
+
+            &:hover {
+                color: $black;
+            }
+
+            &.active {
+                color: $primary;
+                font-weight: 500;
+                border-left-color: $primary;
+            }
+
+            .ti {
+                margin-right: 0.5rem;
+                font-size: 1.125rem;
+                opacity: 0.7;
+            }
         }
 
-        .nav {
-            .nav-link {
-                padding-left: 2.75rem;
+        // Group heading labels (non-clickable)
+        .nav-group-heading {
+            .nav-group-label {
+                display: flex;
+                align-items: center;
+                padding: 0.75rem 1.5rem 0.25rem;
+                font-size: $font-size-xs;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                color: $gray-600;
 
-                @include media-breakpoint-up(md) {
-                    padding-left: 2.25rem;
+                .ti {
+                    margin-right: 0.5rem;
+                    font-size: 1rem;
+                    opacity: 0.6;
                 }
+            }
+        }
+
+        // Sub-item links (components under a group)
+        .nav-sub-item .nav-link {
+            padding-left: 2.75rem;
+
+            @include media-breakpoint-up(md) {
+                padding-left: 2.25rem;
             }
         }
 
@@ -121,6 +160,46 @@
 .main-content {
     @include media-breakpoint-up(md) {
         margin-left: 220px
+    }
+}
+
+// Smooth scrolling with offset for sticky nav on mobile
+html {
+    scroll-behavior: smooth;
+    scroll-padding-top: 1rem;
+
+    @include media-breakpoint-down(md) {
+        scroll-padding-top: 56px;
+    }
+}
+
+// Component section spacing
+.component-section {
+    padding-top: 3rem;
+    padding-bottom: 1rem;
+}
+
+// Section group headings
+.section-group-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 3rem;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0;
+
+    .ti {
+        font-size: 1.125rem;
+        color: $gray-500;
+    }
+
+    h6 {
+        margin-bottom: 0;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: $gray-500;
+        font-size: $font-size-xs;
     }
 }
 
@@ -161,9 +240,22 @@
 
     .main-nav .nav-link {
         color: #a8b0c0;
-        &:hover, &.active {
+        &:hover {
             color: #e8eaf0;
         }
+        &.active {
+            color: #6699ff;
+            border-left-color: #6699ff;
+        }
+    }
+
+    .main-nav .nav-group-label {
+        color: #6e7a91;
+    }
+
+    .section-group-heading .ti,
+    .section-group-heading h6 {
+        color: #6e7a91;
     }
 
     .main-content {

--- a/docs/assets/js/docs.js
+++ b/docs/assets/js/docs.js
@@ -1,14 +1,53 @@
 // JS file for docs features and ui demos
 
-// main nav
+// ═══════════════════════════════════════════
+// SCROLL-SPY: highlight active sidebar link
+// ═══════════════════════════════════════════
 (function () {
-    const myCollapsible = document.getElementById('components')
-    myCollapsible.addEventListener('shown.bs.collapse', event => {
-        location.href = '/components/alerts/';
-    })
-});
+    var sidebarNav = document.getElementById('sidebar-nav');
+    if (!sidebarNav) return;
 
-// charts
+    // Initialize Bootstrap ScrollSpy on the body, targeting sidebar nav
+    var scrollSpy = new bootstrap.ScrollSpy(document.body, {
+        target: '#sidebar-nav',
+        offset: 100,
+        smoothScroll: true
+    });
+
+    // Update URL hash on scroll-spy activation
+    document.addEventListener('activate.bs.scrollspy', function (e) {
+        var id = e.relatedTarget;
+        if (id && id !== '#top') {
+            history.replaceState(null, '', id);
+        }
+    });
+
+    // Mobile: close hamburger menu after clicking a nav link
+    var navCollapse = document.getElementById('sidebarCollapse');
+    if (navCollapse) {
+        sidebarNav.addEventListener('click', function (e) {
+            var link = e.target.closest('a.nav-link');
+            if (link && window.innerWidth < 768) {
+                var bsCollapse = bootstrap.Collapse.getInstance(navCollapse);
+                if (bsCollapse) bsCollapse.hide();
+            }
+        });
+    }
+
+    // On page load with hash, scroll to that section
+    if (window.location.hash) {
+        var target = document.querySelector(window.location.hash);
+        if (target) {
+            setTimeout(function () {
+                target.scrollIntoView({ behavior: 'smooth' });
+            }, 100);
+        }
+    }
+})();
+
+// ═══════════════════════════════════════════
+// CHARTS
+// ═══════════════════════════════════════════
 var lineComparison = document.getElementById('lineComparison');
 
 if (typeof Chart !== 'undefined' && lineComparison) {

--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 1
+section: feedback
+order: 8
+permalink: false
 title: "Alerts"
 description: Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages. Please see the official <a href="https://getbootstrap.com/docs/5.2/components/alerts/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/badges.md
+++ b/docs/components/badges.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 7
+section: feedback
+order: 9
+permalink: false
 title: "Badges"
 description: Please read the official <a href="https://getbootstrap.com/docs/5.2/components/badge/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 2
+section: actions
+order: 3
+permalink: false
 title: "Buttons"
 description: Use Bootstrap’s custom button styles for actions in forms, dialogs, and more with support for multiple sizes, states, and more. Please read the  <a href="https://getbootstrap.com/docs/5.2/components/buttons/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 3
+section: layout
+order: 1
+permalink: false
 title: "Cards"
 description: Bootstrap’s cards provide a flexible and extensible content container with multiple variants and options. Please read the official <a href="https://getbootstrap.com/docs/5.2/components/card/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/charts.md
+++ b/docs/components/charts.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 3
+section: data
+order: 12
+permalink: false
 title: "Charts"
 description: Chart.js is an excellent, fully customizable charting library bundled with a custom theme and styling. See examples below and <a href="https://www.chartjs.org/" target="_blank">Chart.js</a> documenation for deep reference on chart integration.
 

--- a/docs/components/datepicker.md
+++ b/docs/components/datepicker.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 3
+section: actions
+order: 7
+permalink: false
 title: "Date Picker"
 description: flatpickr.js is an excellent full featured date picker library that comes bundled and styled to work natively. See <a target="_blank" href="https://flatpickr.js.org/examples/">flatpickr.js docs</a> for additional options to when initializing.
 ---

--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 5
+section: actions
+order: 4
+permalink: false
 title: "Forms"
 description: NEXT Commerce Design System supports all of Bootstrap's default form styling. Please read the <a href="https://getbootstrap.com/docs/5.2/forms/overview/" target="_blank">official documentation</a> for a full list of options from Bootstrap's core library.
 ---

--- a/docs/components/icons.md
+++ b/docs/components/icons.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 5
+section: data
+order: 13
+permalink: false
 title: "Icons"
 description: "<a href='https://tabler.io/icons' target='_blank'>Tabler icons</a> comes fully bundled for a large selection of over 5,900 icons for UI elements that need a little extra spark."
 ---

--- a/docs/components/loaders.md
+++ b/docs/components/loaders.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 7
+section: feedback
+order: 10
+permalink: false
 title: "Loaders"
 description: Available loaders to use while waiting for content to load.
 

--- a/docs/components/navigation.md
+++ b/docs/components/navigation.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 6
+section: actions
+order: 5
+permalink: false
 title: "Navigation"
 description: NEXT's in-app navigation follows the Bootstrap tabbed navigation. Please read the <a href="https://getbootstrap.com/docs/5.2/components/navs-tabs/" target="_blank">official documentation</a> for a full list of options from Bootstrap's core library.
 
@@ -50,11 +52,11 @@ description: NEXT's in-app navigation follows the Bootstrap tabbed navigation. P
 </div>
 </div>
 </div>
-## Example with Javascript Behaviour
-<div class=" mb-5">
+<h2>Example with Javascript Behaviour</h2>
+<div class="mb-5">
   <div class="card">
     <div class="card-body">
-      <ul class="nav nav-tabs ">
+      <ul class="nav nav-tabs">
           <li class="nav-item" role="presentation">
             <button class="nav-link active" id="link1-tab" data-bs-toggle="tab" data-bs-target="#link1-tab-pane" type="button" role="tab" aria-controls="link1-tab-pane" aria-selected="true">Link 1</button>
           </li>
@@ -68,7 +70,7 @@ description: NEXT's in-app navigation follows the Bootstrap tabbed navigation. P
             <button class="nav-link" id="link4-tab" data-bs-toggle="tab" data-bs-target="#link4-tab-pane" type="button" role="tab" aria-controls="link4-tab-pane" aria-selected="false" disabled>Link 4 Disabled</button>
           </li>
         </ul>
-      <div class="tab-content" id="myTabContent">
+      <div class="tab-content mt-3" id="myTabContent">
         <div class="tab-pane fade show active" id="link1-tab-pane" role="tabpanel" aria-labelledby="link1-tab" tabindex="0">Link tab 1 content...</div>
         <div class="tab-pane fade" id="link2-tab-pane" role="tabpanel" aria-labelledby="link2-tab" tabindex="0">Link tab 2 content...</div>
         <div class="tab-pane fade" id="link3-tab-pane" role="tabpanel" aria-labelledby="link3-tab" tabindex="0">Link tab 3 content...</div>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 7
+section: actions
+order: 6
+permalink: false
 title: "Pagination"
 description: Indicates a series of related content exists across multiple pages. Please see the official <a href="https://getbootstrap.com/docs/5.2/components/pagination/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/tables.md
+++ b/docs/components/tables.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 4
+section: layout
+order: 2
+permalink: false
 title: "Tables"
 description: Please read the official <a href="https://getbootstrap.com/docs/5.2/components/breadcrumb/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/components/timeline.md
+++ b/docs/components/timeline.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 7
+section: data
+order: 14
+permalink: false
 title: "Timeline"
 description: Timelines are a great way to show historical events to and provide context to for how things have changed over time.
 ---

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -1,7 +1,9 @@
 ---
 layout: page-content
 group: components
-order: 7
+section: feedback
+order: 11
+permalink: false
 title: "Tooltips"
 description: Please read the official <a href="https://getbootstrap.com/docs/5.2/components/tooltips/" target="_blank">Bootstrap documentation</a> for a full list of options.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
-layout: page-content
-title: "Getting Started"
-description: Getting started with the NEXT Commerce Design System
+layout: playground
+title: "NEXT Commerce Design System"
+description: The frontend framework for apps that integrate with the NEXT platform.
 ---
 The NEXT Commerce Design System is the frontend framework for apps that integrate with the NEXT platform.
 
@@ -107,7 +107,4 @@ Copy the html below into a new `layout.html` in your project and you're well on 
 ```
 
 
-### Next Steps
-
-Once you have your base layout, you can start using components such as [cards](/components/cards/) in your design.
 


### PR DESCRIPTION
## Summary
- Convert docs from sparse multi-page portal to single scrollable playground
- All 14 components rendered as sections on one page with anchor navigation
- Sidebar redesigned to match NEXT platform: group headings with Tabler icons, static (non-collapsible) groups, active state with blue left border indicator
- Conceptual section grouping: Getting Started, Layout, Actions, Feedback, Data
- Bootstrap ScrollSpy highlights active sidebar link on scroll
- URL hash updates on scroll (deep-linkable: /#buttons, /#charts, etc.)
- Mobile: hamburger auto-closes on anchor link tap
- Skip-to-content accessibility link
- Lightweight footer: GitHub link + Back to top
- Dark mode parity for all new sidebar elements

### Bug fixes included
- Navigation component: `## Example with Javascript Behaviour` now renders as proper h2 (was literal text)
- Navigation component: tab content spacing fixed (mt-3 on .tab-content)

## Pre-Landing Review
No issues found.

## Design Review
Design Review (FULL): 8/10 overall. 6 design decisions locked in during /plan-design-review.

## Test plan
- [x] Eleventy build succeeds (5 files written, 14 component sections rendered)
- [x] Docs CSS compiles without errors
- [x] All 14 component sections present with correct IDs
- [x] 4 section group headings rendered (Layout, Actions, Feedback, Data)
- [x] ScrollSpy active state verified visually (blue left border on active link)
- [x] Footer renders with GitHub link and Back to top
- [x] Skip-to-content link present
- [x] Navigation heading bug fixed (renders as h2)
- [x] Tab content spacing fixed (margin between tabs and content)

Generated with [Claude Code](https://claude.com/claude-code)